### PR TITLE
Improved GuiNumberInput by allowing for validation on focus change

### DIFF
--- a/src/main/java/de/johni0702/minecraft/gui/element/AbstractGuiTextField.java
+++ b/src/main/java/de/johni0702/minecraft/gui/element/AbstractGuiTextField.java
@@ -83,6 +83,7 @@ public abstract class AbstractGuiTextField<T extends AbstractGuiTextField<T>>
     private ReadableDimension size = new Dimension(0, 0); // Size of last render
 
     private Consumer<String> textChanged;
+    private Consumer<Boolean> focusChanged;
     private Runnable onEnter;
 
     public AbstractGuiTextField() {
@@ -100,6 +101,8 @@ public abstract class AbstractGuiTextField<T extends AbstractGuiTextField<T>>
             this.text = text;
         }
         selectionPos = cursorPos = text.length();
+        //omitting this may cause the client to crash when replacing a long with a short text value
+        currentOffset = 0;
         return getThis();
     }
 
@@ -360,7 +363,10 @@ public abstract class AbstractGuiTextField<T extends AbstractGuiTextField<T>>
         if (isFocused && !this.focused) {
             this.blinkCursorTick = 0; // Restart blinking to indicate successful focus
         }
-        this.focused = isFocused;
+        if (this.focused != isFocused) {
+            this.focused = isFocused;
+            onFocusChanged(this.focused);
+        }
         return getThis();
     }
 
@@ -560,6 +566,15 @@ public abstract class AbstractGuiTextField<T extends AbstractGuiTextField<T>>
         }
     }
 
+    /**
+     * Called when the element has been focused or unfocused
+     */
+    protected void onFocusChanged(boolean focused) {
+        if (focusChanged != null) {
+            focusChanged.consume(focused);
+        }
+    }
+
     @Override
     public T onEnter(Runnable onEnter) {
         this.onEnter = onEnter;
@@ -569,6 +584,12 @@ public abstract class AbstractGuiTextField<T extends AbstractGuiTextField<T>>
     @Override
     public T onTextChanged(Consumer<String> textChanged) {
         this.textChanged = textChanged;
+        return getThis();
+    }
+
+    @Override
+    public T onFocusChange(Consumer<Boolean> focusChanged) {
+        this.focusChanged = focusChanged;
         return getThis();
     }
 

--- a/src/main/java/de/johni0702/minecraft/gui/element/IGuiNumberField.java
+++ b/src/main/java/de/johni0702/minecraft/gui/element/IGuiNumberField.java
@@ -41,6 +41,8 @@ public interface IGuiNumberField<T extends IGuiNumberField<T>> extends IGuiTextF
     T setMinValue(int minValue);
     T setMaxValue(int maxValue);
 
+    T setValidateOnFocusChange(boolean validateOnFocusChange);
+
     /**
      * Sets the amount of digits allowed after the decimal point.
      * A value of {@code 0} is equal to integer precision.

--- a/src/main/java/de/johni0702/minecraft/gui/element/advanced/AbstractGuiTextArea.java
+++ b/src/main/java/de/johni0702/minecraft/gui/element/advanced/AbstractGuiTextArea.java
@@ -32,6 +32,7 @@ import de.johni0702.minecraft.gui.function.Clickable;
 import de.johni0702.minecraft.gui.function.Focusable;
 import de.johni0702.minecraft.gui.function.Tickable;
 import de.johni0702.minecraft.gui.function.Typeable;
+import de.johni0702.minecraft.gui.utils.Consumer;
 import lombok.Getter;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiScreen;
@@ -58,6 +59,8 @@ public abstract class AbstractGuiTextArea<T extends AbstractGuiTextArea<T>>
     private boolean focused;
     @Getter
     private Focusable next, previous;
+
+    private Consumer<Boolean> focusChanged;
 
     // Content
     @Getter
@@ -428,7 +431,10 @@ public abstract class AbstractGuiTextArea<T extends AbstractGuiTextArea<T>>
         if (isFocused && !this.focused) {
             this.blinkCursorTick = 0; // Restart blinking to indicate successful focus
         }
-        this.focused = isFocused;
+        if (this.focused != isFocused) {
+            this.focused = isFocused;
+            onFocusChanged(this.focused);
+        }
         return getThis();
     }
 
@@ -676,5 +682,20 @@ public abstract class AbstractGuiTextArea<T extends AbstractGuiTextArea<T>>
     public T setTextColorDisabled(ReadableColor textColorDisabled) {
         this.textColorDisabled = textColorDisabled;
         return getThis();
+    }
+
+    @Override
+    public T onFocusChange(Consumer<Boolean> focusChanged) {
+        this.focusChanged = focusChanged;
+        return getThis();
+    }
+
+    /**
+     * Called when the element has been focused or unfocused
+     */
+    protected void onFocusChanged(boolean focused) {
+        if (focusChanged != null) {
+            focusChanged.consume(focused);
+        }
     }
 }

--- a/src/main/java/de/johni0702/minecraft/gui/element/advanced/IGuiTextArea.java
+++ b/src/main/java/de/johni0702/minecraft/gui/element/advanced/IGuiTextArea.java
@@ -28,7 +28,7 @@ import de.johni0702.minecraft.gui.element.GuiElement;
 import de.johni0702.minecraft.gui.function.Focusable;
 import org.lwjgl.util.ReadableColor;
 
-public interface IGuiTextArea<T extends IGuiTextArea<T>> extends GuiElement<T>,Focusable {
+public interface IGuiTextArea<T extends IGuiTextArea<T>> extends GuiElement<T>, Focusable<T> {
     void setText(String[] lines);
 
     String[] getText();

--- a/src/main/java/de/johni0702/minecraft/gui/function/Focusable.java
+++ b/src/main/java/de/johni0702/minecraft/gui/function/Focusable.java
@@ -24,10 +24,14 @@
  */
 package de.johni0702.minecraft.gui.function;
 
+import de.johni0702.minecraft.gui.utils.Consumer;
+
 public interface Focusable<T extends Focusable<T>> {
 
     boolean isFocused();
     T setFocused(boolean focused);
+
+    T onFocusChange(Consumer<Boolean> consumer);
 
     Focusable getNext();
     T setNext(Focusable next);


### PR DESCRIPTION
Improved GuiNumberInput user experience by allowing for validation on focus change, i.e. when the user clicks (or tabs) out of the GuiNumberInput.
While doing so, I also added the possibility to have a Focus change listener in form of a `Consumer<Boolean>` for elements that implement the `Focusable` interface.
